### PR TITLE
Don't throw an error when there is no auth header and no token.

### DIFF
--- a/includes/class-micropub-authorize.php
+++ b/includes/class-micropub-authorize.php
@@ -162,7 +162,7 @@ class Micropub_Authorize {
 		$auth  = static::get_authorization_header();
 		$token = mp_get( $_POST, 'access_token' ); // phpcs:ignore
 		if ( ! $auth && ! $token ) {
-			static::$error = new WP_Micropub_Error( 'unauthorized', 'missing access token', 401 );
+			# static::$error = new WP_Micropub_Error( 'unauthorized', 'missing access token', 401 );
 			return $user_id;
 		}
 

--- a/includes/class-micropub-authorize.php
+++ b/includes/class-micropub-authorize.php
@@ -162,7 +162,6 @@ class Micropub_Authorize {
 		$auth  = static::get_authorization_header();
 		$token = mp_get( $_POST, 'access_token' ); // phpcs:ignore
 		if ( ! $auth && ! $token ) {
-			# static::$error = new WP_Micropub_Error( 'unauthorized', 'missing access token', 401 );
 			return $user_id;
 		}
 

--- a/includes/class-micropub-authorize.php
+++ b/includes/class-micropub-authorize.php
@@ -12,7 +12,7 @@ if ( ! defined( 'MICROPUB_TOKEN_ENDPOINT' ) ) {
 	define( 'MICROPUB_TOKEN_ENDPOINT', 'https://tokens.indieauth.com/token' );
 }
 
-add_action( 'plugins_loaded', array( 'Micropub_Authorize', 'init' ) );
+add_action( 'plugins_loaded', array( 'Micropub_Authorize', 'init' ), 30 );
 
 /**
  * Micropub IndieAuth Authorization Class


### PR DESCRIPTION
Not ideal, but this way it just returns the `$user_id` which is probably 0 at that point. This should solve #172 - at least it did for me.