### PR TITLE
suppress PHP `strpos(): Empty needle` warning

### DIFF
--- a/includes/class-micropub-authorize.php
+++ b/includes/class-micropub-authorize.php
@@ -163,7 +163,7 @@ class Micropub_Authorize {
 		$token = mp_get( $_POST, 'access_token' ); // phpcs:ignore
 		if ( ! $auth && ! $token ) {
 			// Fail if micropub is in the requested path
-			if ( false !== strpos( MICROPUB_NAMESPACE, $_SERVER['REQUEST_URI'] ) ) {
+			if ( ! empty( $_SERVER['REQUEST_URI'] ) && false !== strpos( MICROPUB_NAMESPACE, $_SERVER['REQUEST_URI'] ) ) {
 				static::$error = new WP_Micropub_Error( 'unauthorized', 'missing access token', 401 );
 			}
 			return $user_id;


### PR DESCRIPTION
when running outside of a web server, e.g. in wp-cli.

```
PHP Warning: strpos(): Empty needle in /usr/home/ryancb/public_html/w/wp-content/plugins/micropub/includes/class-micropub-authorize.php on line 166
```