### PR TITLE
Fix issue with media not getting attached to post

### DIFF
--- a/includes/class-micropub-media.php
+++ b/includes/class-micropub-media.php
@@ -346,7 +346,7 @@ class Micropub_Media {
 			// Attach media to post
 			wp_update_post(
 				array(
-					'post_ID'     => $id,
+					'ID'          => $id,
 					'post_parent' => $post_id,
 				)
 			);


### PR DESCRIPTION
wp_update_post requires the 'ID' parameter. http://codex.wordpress.org/Function_Reference/wp_update_post

I was able to get this to work with a local WP install and local version of OwnYourGram.

Fixes #173 
