### PR TITLE
Fix PHP 7.4 unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ env:
   - SVN_REPO: https://plugins.svn.wordpress.org/micropub/
 matrix:
   include:
+  - php: 7.4
+    env: WP_VERSION=latest WP_MULTISITE=0 WP_PLUGIN_DEPLOY=1
+  - php: 7.4
+    env: WP_VERSION=latest WP_MULTISITE=1 WP_PLUGIN_DEPLOY=1
   - php: 7.2
     env: WP_VERSION=latest WP_MULTISITE=0 WP_PLUGIN_DEPLOY=1
   - php: 7.0
@@ -43,7 +47,7 @@ before_script:
   # Install the specified version of PHPUnit depending on the PHP version:
   if [[ "$WP_TRAVISCI" == "travis:phpunit" ]]; then
     case "$TRAVIS_PHP_VERSION" in
-      7.2|7.1|7.0|nightly)
+      7.4|7.2|7.1|7.0|nightly)
         echo "Using PHPUnit 6.x"
         composer global require "phpunit/phpunit:^6"
         ;;

--- a/tests/test_authorize.php
+++ b/tests/test_authorize.php
@@ -41,6 +41,7 @@ class Micropub_Authorize_Test extends WP_UnitTestCase {
 	}
 	public function setUp() {
 		// parent::setUp();
+		wp_update_user( array( 'ID' => 1, 'user_url' => '/wp-admin/' ) );
 	}
 
 	public function test_author_url() {
@@ -56,8 +57,8 @@ class Micropub_Authorize_Test extends WP_UnitTestCase {
 	}
 
 	public function test_home_url() {
-		wp_update_user( array( 'ID' => self::$author_id, 'user_url' => '/users/' . self::$author_id ) );
-		$user_id = Micropub_Authorize::url_to_user( '/users/' . self::$author_id );
+		wp_update_user( array( 'ID' => self::$author_id, 'user_url' => home_url() ) );
+		$user_id = Micropub_Authorize::url_to_user( home_url() );
 		$this->assertEquals( self::$author_id, $user_id );
 		wp_update_user( array( 'ID' => self::$author_id, 'user_url' => 'http://tacos.com' ) );
 	}

--- a/tests/test_authorize.php
+++ b/tests/test_authorize.php
@@ -56,8 +56,8 @@ class Micropub_Authorize_Test extends WP_UnitTestCase {
 	}
 
 	public function test_home_url() {
-		wp_update_user( array( 'ID' => self::$author_id, 'user_url' => home_url() ) );
-		$user_id = Micropub_Authorize::url_to_user( home_url() );
+		wp_update_user( array( 'ID' => self::$author_id, 'user_url' => '/users/' . self::$author_id ) );
+		$user_id = Micropub_Authorize::url_to_user( '/users/' . self::$author_id );
 		$this->assertEquals( self::$author_id, $user_id );
 		wp_update_user( array( 'ID' => self::$author_id, 'user_url' => 'http://tacos.com' ) );
 	}


### PR DESCRIPTION
Make failing url_to_user predictable and unique

## Background

I've not looked at the database, but I'm fairly certain there are two users with the `home_url()`

Maybe there is something more to clean up but this I feel captures the unique nature of each individual in Indieweb by having each user have their own URL

It seems to fix tests using PHP 7.4.4 on Ubuntu Bionic

## Solution

don't use home_url, but rather a unique url / path in this test-case
